### PR TITLE
Replace hardcoded constant use with variable

### DIFF
--- a/examples/analog_input_with_time_stamps.py
+++ b/examples/analog_input_with_time_stamps.py
@@ -74,7 +74,7 @@ def analog_in(my_board, pin):
         while True:
             time.sleep(POLL_TIME)
             # retrieve both the value and time stamp with each poll
-            value, time_stamp = board.analog_read(ANALOG_PIN)
+            value, time_stamp = board.analog_read(pin)
             # format the time stamp
             formatted_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time_stamp))
             print(

--- a/examples/analog_input_with_time_stamps.py
+++ b/examples/analog_input_with_time_stamps.py
@@ -78,7 +78,7 @@ def analog_in(my_board, pin):
             # format the time stamp
             formatted_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time_stamp))
             print(
-                f'Reading latest analog input data for pin {ANALOG_PIN} = {value} change received on {formatted_time} '
+                f'Reading latest analog input data for pin {pin} = {value} change received on {formatted_time} '
                 f'(raw_time: {time_stamp})')
     except KeyboardInterrupt:
         my_board.shutdown()


### PR DESCRIPTION
Replace the hardcoded `ANALOG_PIN` constant with the `pin` variable so the function behaves as expected when called without `ANALOG_PIN` as the argument. 