### PR TITLE
Fix   _i2c_read_request function to allow direct I2C read without preliminary I2C write

### DIFF
--- a/pymata4/pymata4.py
+++ b/pymata4/pymata4.py
@@ -829,7 +829,7 @@ class Pymata4(threading.Thread):
         if address not in self.i2c_map:
             with self.the_i2c_map_lock:
                 self.i2c_map[address] = {'value': None, 'callback': callback}
-        if register:
+        if register is not None:
             data = [address, read_type, register & 0x7f, (register >> 7) & 0x7f,
                     number_of_bytes & 0x7f, (number_of_bytes >> 7) & 0x7f]
         else:

--- a/pymata4/pymata4.py
+++ b/pymata4/pymata4.py
@@ -709,7 +709,7 @@ class Pymata4(threading.Thread):
 
         :param address: i2c device address
 
-        :param register: i2c register
+        :param register: i2c register (or None if no register selection is needed)
 
         :param number_of_bytes: number of bytes to be read
 
@@ -815,7 +815,7 @@ class Pymata4(threading.Thread):
 
         :param address: i2c device address
 
-        :param register: register number (can be set to zero)
+        :param register: register number (or None if no register selection is needed)
 
         :param number_of_bytes: number of bytes expected to be returned
 
@@ -829,8 +829,12 @@ class Pymata4(threading.Thread):
         if address not in self.i2c_map:
             with self.the_i2c_map_lock:
                 self.i2c_map[address] = {'value': None, 'callback': callback}
-        data = [address, read_type, register & 0x7f, (register >> 7) & 0x7f,
-                number_of_bytes & 0x7f, (number_of_bytes >> 7) & 0x7f]
+        if register:
+            data = [address, read_type, register & 0x7f, (register >> 7) & 0x7f,
+                    number_of_bytes & 0x7f, (number_of_bytes >> 7) & 0x7f]
+        else:
+            data = [address, read_type, 
+                    number_of_bytes & 0x7f, (number_of_bytes >> 7) & 0x7f]
         self._send_sysex(PrivateConstants.I2C_REQUEST, data)
 
     def i2c_write(self, address, args):


### PR DESCRIPTION
allow direct read from the device without initial register selection.
This should match the two possible I2C read supported by the
FirmataExpress firmware.

Explanation: With the current code, an I2C write occurs to select a register before the I2C read access. 
This prevents usage of I2C circuits like an I2C multiplexer (like the [tca9548a](https://learn.adafruit.com/adafruit-tca9548a-1-to-8-i2c-multiplexer-breakout) )  with pymata4.
The FirmataExpress supports the two different types of access (with or without the first I2C write) by looking at the number of data passed in the sysex call.
(see https://github.com/MrYsLab/FirmataExpress/blob/eff00dba368b10286a6bbfe753b0de44850e1362/examples/FirmataExpress/FirmataExpress.ino#L625)

The pull-request does not change the other I2C read functions but it is very likely that the same documentation update is needed

Before the fix  (an simple 1-byte I2C read):
```python
board.i2c_read(I2C_MUX_SLAVE_ADDRESS, 0, 1, i2c_read_callback)
```
![before_fix](https://user-images.githubusercontent.com/811506/83812804-6e21e900-a6bc-11ea-89be-9071dd586a61.png)

After the fix
```python
board.i2c_read(I2C_MUX_SLAVE_ADDRESS, None, 1, i2c_read_callback)
```
![after-fix](https://user-images.githubusercontent.com/811506/83812823-7548f700-a6bc-11ea-9d76-2a5c4dfe42b8.png)



