### PR TITLE
fix: provide Python 3.6 backward support

### DIFF
--- a/pymata4/pymata4.py
+++ b/pymata4/pymata4.py
@@ -122,10 +122,10 @@ class Pymata4(threading.Thread):
         # check to make sure that Python interpreter is version 3.7 or greater
         python_version = sys.version_info
         if python_version[0] >= 3:
-            if python_version[1] >= 7:
+            if python_version[1] >= 6:
                 pass
             else:
-                raise RuntimeError("ERROR: Python 3.7 or greater is "
+                raise RuntimeError("ERROR: Python 3.6 or greater is "
                                    "required for use of this program.")
 
         # save input parameters as instance variables

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Intended Audience :: Education',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
#40 

This is my attempt to provide Python 3.6 support. So far everything works fine as far as I can test, but sonar is not working on my board for some reason, in which I made sure that it is not hardware issue since I tested with some standard Arduino sonar sketch for Mega, I will work through it.